### PR TITLE
We need to include a 'website' field

### DIFF
--- a/queries/govuk/visitors.json
+++ b/queries/govuk/visitors.json
@@ -4,7 +4,11 @@
     "data-type": "visitors"
   }, 
   "entrypoint": "performanceplatform.collector.ga", 
-  "options": {}, 
+  "options": {
+    "additionalFields": {
+      "website": "govuk"
+    }
+  }, 
   "query": {
     "id": "ga:56580952", 
     "metrics": [


### PR DESCRIPTION
We need to include a field of 'website' so that we know that these
values are for govuk and not businesslink or directgov.
