### PR TITLE
Move FCO payment services to service domains

### DIFF
--- a/queries/pay-foreign-marriage-certificates/journey.json
+++ b/queries/pay-foreign-marriage-certificates/journey.json
@@ -6,13 +6,10 @@
   "entrypoint": "performanceplatform.collector.ga", 
   "options": {}, 
   "query": {
+    "id": "ga:75452311", 
     "dimensions": [
       "eventCategory"
     ], 
-    "filters": [
-      "eventCategory=~^pay-foreign-marriage-certificates:"
-    ], 
-    "id": "ga:56580952", 
     "metrics": [
       "uniqueEvents"
     ]

--- a/queries/pay-foreign-marriage-certificates/realtime.json
+++ b/queries/pay-foreign-marriage-certificates/realtime.json
@@ -6,8 +6,7 @@
   "entrypoint": "performanceplatform.collector.ga.realtime", 
   "options": {}, 
   "query": {
-    "filters": "ga:pagePath=~/pay-foreign-marriage-certificates", 
-    "ids": "ga:84779739", 
+    "ids": "ga:75452311", 
     "metrics": "ga:activeVisitors"
   }, 
   "token": "ga-realtime"

--- a/queries/pay-legalisation-drop-off/journey.json
+++ b/queries/pay-legalisation-drop-off/journey.json
@@ -9,10 +9,7 @@
     "dimensions": [
       "eventCategory"
     ], 
-    "filters": [
-      "eventCategory=~^pay-legalisation-drop-off:"
-    ], 
-    "id": "ga:56580952", 
+    "id": "ga:75449560", 
     "metrics": [
       "uniqueEvents"
     ]

--- a/queries/pay-legalisation-drop-off/realtime.json
+++ b/queries/pay-legalisation-drop-off/realtime.json
@@ -6,8 +6,7 @@
   "entrypoint": "performanceplatform.collector.ga.realtime", 
   "options": {}, 
   "query": {
-    "filters": "ga:pagePath=~/pay-legalisation-drop-off", 
-    "ids": "ga:84775792", 
+    "ids": "ga:75449560", 
     "metrics": "ga:activeVisitors"
   }, 
   "token": "ga-realtime"

--- a/queries/pay-legalisation-post/journey.json
+++ b/queries/pay-legalisation-post/journey.json
@@ -9,10 +9,7 @@
     "dimensions": [
       "eventCategory"
     ], 
-    "filters": [
-      "eventCategory=~^pay-legalisation-post:"
-    ], 
-    "id": "ga:56580952", 
+    "id": "ga:75447363", 
     "metrics": [
       "uniqueEvents"
     ]

--- a/queries/pay-legalisation-post/realtime.json
+++ b/queries/pay-legalisation-post/realtime.json
@@ -6,8 +6,7 @@
   "entrypoint": "performanceplatform.collector.ga.realtime", 
   "options": {}, 
   "query": {
-    "filters": "ga:pagePath=~/pay-legalisation-post", 
-    "ids": "ga:84775792", 
+    "ids": "ga:75447363", 
     "metrics": "ga:activeVisitors"
   }, 
   "token": "ga-realtime"

--- a/queries/pay-register-birth-abroad/journey.json
+++ b/queries/pay-register-birth-abroad/journey.json
@@ -9,10 +9,7 @@
     "dimensions": [
       "eventCategory"
     ], 
-    "filters": [
-      "eventCategory=~^pay-register-birth-abroad:"
-    ], 
-    "id": "ga:56580952", 
+    "id": "ga:75449347", 
     "metrics": [
       "uniqueEvents"
     ]

--- a/queries/pay-register-birth-abroad/realtime.json
+++ b/queries/pay-register-birth-abroad/realtime.json
@@ -6,8 +6,7 @@
   "entrypoint": "performanceplatform.collector.ga.realtime", 
   "options": {}, 
   "query": {
-    "filters": "ga:pagePath=~/pay-register-birth-abroad", 
-    "ids": "ga:84775377", 
+    "ids": "ga:75449347", 
     "metrics": "ga:activeVisitors"
   }, 
   "token": "ga-realtime"

--- a/queries/pay-register-death-abroad/journey.json
+++ b/queries/pay-register-death-abroad/journey.json
@@ -9,10 +9,7 @@
     "dimensions": [
       "eventCategory"
     ], 
-    "filters": [
-      "eventCategory=~^pay-register-death-abroad:"
-    ], 
-    "id": "ga:56580952", 
+    "id": "ga:75441670", 
     "metrics": [
       "uniqueEvents"
     ]

--- a/queries/pay-register-death-abroad/realtime.json
+++ b/queries/pay-register-death-abroad/realtime.json
@@ -6,8 +6,7 @@
   "entrypoint": "performanceplatform.collector.ga.realtime", 
   "options": {}, 
   "query": {
-    "filters": "ga:pagePath=~/pay-register-death-abroad", 
-    "ids": "ga:84775377", 
+    "ids": "ga:75441670", 
     "metrics": "ga:activeVisitors"
   }, 
   "token": "ga-realtime"


### PR DESCRIPTION
The following FCO services are moving from GOV.UK onto their own
service.gov.uk subdomains.
- pay-foreign-marriage-certificate
- pay-legalisation-drop-off
- pay-legalisation-post
- pay-register-birth-abroad
- pay-register-death-abroad
