### PR TITLE
Override the `dataType` for licensing journey

### DIFF
--- a/queries/licensing/journey.json
+++ b/queries/licensing/journey.json
@@ -4,7 +4,9 @@
     "data-type": "journey"
   }, 
   "entrypoint": "performanceplatform.collector.ga", 
-  "options": {}, 
+  "options": {
+    "dataType": "licensing_overview_journey"
+  },
   "query": {
     "dimensions": [
       "eventCategory"


### PR DESCRIPTION
This nasty hack is preferable to having to change code in limelight.
