### PR TITLE
Override data type as this is used in a multi source collection

### DIFF
--- a/queries/govuk/visitors.json
+++ b/queries/govuk/visitors.json
@@ -15,5 +15,8 @@
       "visitors"
     ]
   }, 
-  "token": "ga"
+  "token": "ga",
+  "options": {
+    "dataType": "govuk_visitors"
+  }
 }


### PR DESCRIPTION
e.g. with datainsight and and businesslink numbers (and corresponging dataTypes)
