### PR TITLE
Add query for visit visa applications

### DIFF
--- a/queries/tier-2-visit-visa/volumetrics.json
+++ b/queries/tier-2-visit-visa/volumetrics.json
@@ -1,0 +1,18 @@
+{
+  "data-set": {
+    "data-group": "tier-2-visit-visa",
+    "data-type": "volumetrics"
+  },
+  "entrypoint": "performanceplatform.collector.ga",
+  "options": {},
+  "query": {
+    "filters": [
+      "pagePath=~^/customer/[^/]+/complete$"
+    ],
+    "id": "ga:81779532",
+    "metrics": [
+      "uniquePageviews"
+    ]
+  },
+  "token": "ga"
+}


### PR DESCRIPTION
This should give us the number of unique visitors to a completion page.

The regex should match:

```
/customer/*/complete
```

But should NOT match:

```
/customer/*/start/complete
```

So I've matched on characters, numbers and hyphens. I assume there won't be anything else crazy in the URL. We'll see how that works.

https://www.pivotaltracker.com/story/show/71934810
