### PR TITLE
Add queries for 'renew tax credits' service

### DIFF
--- a/cronjobs
+++ b/cronjobs
@@ -8,47 +8,50 @@
 #
 
 0 0 * * *,queries/carers-allowance/journey.json,credentials/ga.json,tokens/ga.json,performanceplatform.json
-1 0 * * *,queries/driving-test-practical-public/device-usage.json,credentials/ga.json,tokens/ga.json,performanceplatform.json
-2 0 * * *,queries/driving-test-practical-public/journey-help.json,credentials/ga.json,tokens/ga.json,performanceplatform.json
-3 0 * * *,queries/driving-test-practical-public/journey.json,credentials/ga.json,tokens/ga.json,performanceplatform.json
-4 0 * * *,queries/gov-uk-content/devices-count.json,credentials/ga.json,tokens/ga-content.json,performanceplatform.json
-5 0 * * *,queries/gov-uk-content/new-returning-count.json,credentials/ga.json,tokens/ga-content.json,performanceplatform.json
-6 0 * * *,queries/gov-uk-content/organic-rate.json,credentials/ga.json,tokens/ga-content.json,performanceplatform.json
-7 0 * * *,queries/gov-uk-content/pageviews-count.json,credentials/ga.json,tokens/ga-content.json,performanceplatform.json
-8 0 * * *,queries/gov-uk-content/referrers-rate.json,credentials/ga.json,tokens/ga-content.json,performanceplatform.json
-9 0 * * *,queries/gov-uk-content/social-rate.json,credentials/ga.json,tokens/ga-content.json,performanceplatform.json
-10 0 * * *,queries/gov-uk-content/top-collections-count.json,credentials/ga.json,tokens/ga-content.json,performanceplatform.json
-11 0 * * *,queries/gov-uk-content/top-consultations-count.json,credentials/ga.json,tokens/ga-content.json,performanceplatform.json
-12 0 * * *,queries/gov-uk-content/top-count.json,credentials/ga.json,tokens/ga-content.json,performanceplatform.json
-13 0 * * *,queries/gov-uk-content/top-detail-guide-count.json,credentials/ga.json,tokens/ga-content.json,performanceplatform.json
-14 0 * * *,queries/gov-uk-content/top-news-count.json,credentials/ga.json,tokens/ga-content.json,performanceplatform.json
-15 0 * * *,queries/gov-uk-content/top-policy-count.json,credentials/ga.json,tokens/ga-content.json,performanceplatform.json
-16 0 * * *,queries/gov-uk-content/top-publications-count.json,credentials/ga.json,tokens/ga-content.json,performanceplatform.json
-17 0 * * *,queries/gov-uk-content/top-speeches-count.json,credentials/ga.json,tokens/ga-content.json,performanceplatform.json
-18 0 * * *,queries/gov-uk-content/traffic-count.json,credentials/ga.json,tokens/ga-content.json,performanceplatform.json
-19 0 * * *,queries/govuk/browsers.json,credentials/ga.json,tokens/ga.json,performanceplatform.json
-20 0 * * *,queries/govuk/devices.json,credentials/ga.json,tokens/ga.json,performanceplatform.json
-21 0 * * *,queries/govuk/most_viewed.json,credentials/ga.json,tokens/ga.json,performanceplatform.json
-22 0 * * *,queries/govuk/most_viewed_news.json,credentials/ga.json,tokens/ga.json,performanceplatform.json
-23 0 * * *,queries/govuk/most_viewed_policies.json,credentials/ga.json,tokens/ga.json,performanceplatform.json
-24 0 * * *,queries/govuk/trending.json,credentials/ga.json,tokens/ga-trending.json,performanceplatform.json
-25 0 * * *,queries/govuk/visitors.json,credentials/ga.json,tokens/ga.json,performanceplatform.json
-26 0 * * *,queries/insidegov/visitors.json,credentials/ga.json,tokens/ga.json,performanceplatform.json
-27 0 * * *,queries/lasting-power-of-attorney/journey.json,credentials/ga.json,tokens/ga.json,performanceplatform.json
-28 0 * * *,queries/licensing/journey.json,credentials/ga.json,tokens/ga.json,performanceplatform.json
-29 0 * * *,queries/pay-foreign-marriage-certificates/journey.json,credentials/ga.json,tokens/ga.json,performanceplatform.json
-30 0 * * *,queries/pay-legalisation-drop-off/journey.json,credentials/ga.json,tokens/ga.json,performanceplatform.json
-31 0 * * *,queries/pay-legalisation-post/journey.json,credentials/ga.json,tokens/ga.json,performanceplatform.json
-32 0 * * *,queries/pay-register-birth-abroad/journey.json,credentials/ga.json,tokens/ga.json,performanceplatform.json
-33 0 * * *,queries/pay-register-death-abroad/journey.json,credentials/ga.json,tokens/ga.json,performanceplatform.json
-34 0 * * *,queries/student-finance/browser-usage.json,credentials/ga.json,tokens/ga.json,performanceplatform.json
-35 0 * * *,queries/student-finance/device-usage.json,credentials/ga.json,tokens/ga.json,performanceplatform.json
-36 0 * * *,queries/student-finance/journey.json,credentials/ga.json,tokens/ga.json,performanceplatform.json
-37 0 * * *,queries/student-finance/site-traffic.json,credentials/ga.json,tokens/ga.json,performanceplatform.json
-38 0 * * *,queries/tier-2-visit-visa/devices.json,credentials/ga.json,tokens/ga.json,performanceplatform.json
-39 0 * * *,queries/tier-2-visit-visa/journey.json,credentials/ga.json,tokens/ga.json,performanceplatform.json
-40 0 * * *,queries/tier-2-visit-visa/volumetrics.json,credentials/ga.json,tokens/ga.json,performanceplatform.json
-41 0 * * *,queries/view-driving-record/digital-transactions.json,credentials/ga.json,tokens/ga.json,performanceplatform.json
+1 0 * * *,queries/carers-allowance/time-taken-to-complete.json,credentials/ga.json,tokens/ga.json,performanceplatform.json
+2 0 * * *,queries/driving-test-practical-public/device-usage.json,credentials/ga.json,tokens/ga.json,performanceplatform.json
+3 0 * * *,queries/driving-test-practical-public/journey-help.json,credentials/ga.json,tokens/ga.json,performanceplatform.json
+4 0 * * *,queries/driving-test-practical-public/journey.json,credentials/ga.json,tokens/ga.json,performanceplatform.json
+5 0 * * *,queries/gov-uk-content/devices-count.json,credentials/ga.json,tokens/ga-content.json,performanceplatform.json
+6 0 * * *,queries/gov-uk-content/new-returning-count.json,credentials/ga.json,tokens/ga-content.json,performanceplatform.json
+7 0 * * *,queries/gov-uk-content/organic-rate.json,credentials/ga.json,tokens/ga-content.json,performanceplatform.json
+8 0 * * *,queries/gov-uk-content/pageviews-count.json,credentials/ga.json,tokens/ga-content.json,performanceplatform.json
+9 0 * * *,queries/gov-uk-content/referrers-rate.json,credentials/ga.json,tokens/ga-content.json,performanceplatform.json
+10 0 * * *,queries/gov-uk-content/social-rate.json,credentials/ga.json,tokens/ga-content.json,performanceplatform.json
+11 0 * * *,queries/gov-uk-content/top-collections-count.json,credentials/ga.json,tokens/ga-content.json,performanceplatform.json
+12 0 * * *,queries/gov-uk-content/top-consultations-count.json,credentials/ga.json,tokens/ga-content.json,performanceplatform.json
+13 0 * * *,queries/gov-uk-content/top-count.json,credentials/ga.json,tokens/ga-content.json,performanceplatform.json
+14 0 * * *,queries/gov-uk-content/top-detail-guide-count.json,credentials/ga.json,tokens/ga-content.json,performanceplatform.json
+15 0 * * *,queries/gov-uk-content/top-news-count.json,credentials/ga.json,tokens/ga-content.json,performanceplatform.json
+16 0 * * *,queries/gov-uk-content/top-policy-count.json,credentials/ga.json,tokens/ga-content.json,performanceplatform.json
+17 0 * * *,queries/gov-uk-content/top-publications-count.json,credentials/ga.json,tokens/ga-content.json,performanceplatform.json
+18 0 * * *,queries/gov-uk-content/top-speeches-count.json,credentials/ga.json,tokens/ga-content.json,performanceplatform.json
+19 0 * * *,queries/gov-uk-content/traffic-count.json,credentials/ga.json,tokens/ga-content.json,performanceplatform.json
+20 0 * * *,queries/govuk/browsers.json,credentials/ga.json,tokens/ga.json,performanceplatform.json
+21 0 * * *,queries/govuk/devices.json,credentials/ga.json,tokens/ga.json,performanceplatform.json
+22 0 * * *,queries/govuk/most_viewed.json,credentials/ga.json,tokens/ga.json,performanceplatform.json
+23 0 * * *,queries/govuk/most_viewed_news.json,credentials/ga.json,tokens/ga.json,performanceplatform.json
+24 0 * * *,queries/govuk/most_viewed_policies.json,credentials/ga.json,tokens/ga.json,performanceplatform.json
+25 0 * * *,queries/govuk/trending.json,credentials/ga.json,tokens/ga-trending.json,performanceplatform.json
+26 0 * * *,queries/govuk/visitors.json,credentials/ga.json,tokens/ga.json,performanceplatform.json
+27 0 * * *,queries/insidegov/visitors.json,credentials/ga.json,tokens/ga.json,performanceplatform.json
+28 0 * * *,queries/lasting-power-of-attorney/journey.json,credentials/ga.json,tokens/ga.json,performanceplatform.json
+29 0 * * *,queries/licensing/journey.json,credentials/ga.json,tokens/ga.json,performanceplatform.json
+30 0 * * *,queries/pay-foreign-marriage-certificates/journey.json,credentials/ga.json,tokens/ga.json,performanceplatform.json
+31 0 * * *,queries/pay-legalisation-drop-off/journey.json,credentials/ga.json,tokens/ga.json,performanceplatform.json
+32 0 * * *,queries/pay-legalisation-post/journey.json,credentials/ga.json,tokens/ga.json,performanceplatform.json
+33 0 * * *,queries/pay-register-birth-abroad/journey.json,credentials/ga.json,tokens/ga.json,performanceplatform.json
+34 0 * * *,queries/pay-register-death-abroad/journey.json,credentials/ga.json,tokens/ga.json,performanceplatform.json
+35 0 * * *,queries/renew-tax-credits/device-usage.json,credentials/ga.json,tokens/ga.json,performanceplatform.json
+36 0 * * *,queries/renew-tax-credits/journey.json,credentials/ga.json,tokens/ga.json,performanceplatform.json
+37 0 * * *,queries/student-finance/browser-usage.json,credentials/ga.json,tokens/ga.json,performanceplatform.json
+38 0 * * *,queries/student-finance/device-usage.json,credentials/ga.json,tokens/ga.json,performanceplatform.json
+39 0 * * *,queries/student-finance/journey.json,credentials/ga.json,tokens/ga.json,performanceplatform.json
+40 0 * * *,queries/student-finance/site-traffic.json,credentials/ga.json,tokens/ga.json,performanceplatform.json
+41 0 * * *,queries/tier-2-visit-visa/devices.json,credentials/ga.json,tokens/ga.json,performanceplatform.json
+42 0 * * *,queries/tier-2-visit-visa/journey.json,credentials/ga.json,tokens/ga.json,performanceplatform.json
+43 0 * * *,queries/tier-2-visit-visa/volumetrics.json,credentials/ga.json,tokens/ga.json,performanceplatform.json
+44 0 * * *,queries/view-driving-record/digital-transactions.json,credentials/ga.json,tokens/ga.json,performanceplatform.json
 
 
 #
@@ -77,7 +80,6 @@
 19 * * * *,queries/tier-2-visit-visa/monitoring.json,credentials/pingdom.json,tokens/pingdom.json,performanceplatform.json
 20 * * * *,queries/view-driving-record/monitoring.json,credentials/pingdom.json,tokens/pingdom.json,performanceplatform.json
 21 * * * *,queries/waste-carriers-registration/monitoring.json,credentials/pingdom.json,tokens/pingdom.json,performanceplatform.json
-22 * * * *,queries/carers-allowance/time-taken-to-complete.json,credentials/ga.json,tokens/ga.json,performanceplatform.json
 
 
 #
@@ -96,6 +98,7 @@
 1-59/2 * * * *,queries/pay-register-birth-abroad/realtime.json,credentials/ga.json,tokens/ga-realtime.json,performanceplatform.json
 1-59/2 * * * *,queries/pay-register-death-abroad/realtime.json,credentials/ga.json,tokens/ga-realtime.json,performanceplatform.json
 1-59/2 * * * *,queries/register-to-vote/realtime.json,credentials/ga.json,tokens/ga-realtime.json,performanceplatform.json
+1-59/2 * * * *,queries/renew-tax-credits/realtime.json,credentials/ga.json,tokens/ga-realtime.json,performanceplatform.json
 1-59/2 * * * *,queries/sorn/realtime.json,credentials/ga.json,tokens/ga-realtime.json,performanceplatform.json
 1-59/2 * * * *,queries/tax-disc/realtime.json,credentials/ga.json,tokens/ga-realtime.json,performanceplatform.json
 1-59/2 * * * *,queries/tier-2-visit-visa/realtime.json,credentials/ga.json,tokens/ga-realtime.json,performanceplatform.json

--- a/queries/renew-tax-credits/device-usage.json
+++ b/queries/renew-tax-credits/device-usage.json
@@ -1,0 +1,18 @@
+{
+  "data-set": {
+    "data-group": "renewtaxcredits",
+    "data-type": "device-usage"
+  },
+  "entrypoint": "performanceplatform.collector.ga",
+  "options": {},
+  "query": {
+    "dimensions": [
+      "deviceCategory"
+    ],
+    "id": "ga:84609771",
+    "metrics": [
+      "visitors"
+    ]
+  },
+  "token": "ga"
+}

--- a/queries/renew-tax-credits/journey.json
+++ b/queries/renew-tax-credits/journey.json
@@ -1,0 +1,18 @@
+{
+  "data-set": {
+    "data-group": "renewtaxcredits",
+    "data-type": "journey"
+  },
+  "entrypoint": "performanceplatform.collector.ga",
+  "options": {},
+  "query": {
+    "dimensions": [
+      "pagePath"
+    ],
+    "id": "ga:84609771",
+    "metrics": [
+      "uniquePageviews"
+    ]
+  },
+  "token": "ga"
+}

--- a/queries/renew-tax-credits/realtime.json
+++ b/queries/renew-tax-credits/realtime.json
@@ -1,0 +1,13 @@
+{
+  "data-set": {
+    "data-group": "renewtaxcredits",
+    "data-type": "realtime"
+  },
+  "entrypoint": "performanceplatform.collector.ga.realtime",
+  "options": {},
+  "query": {
+    "ids": "ga:84609771",
+    "metrics": "ga:activeVisitors"
+  },
+  "token": "ga-realtime"
+}


### PR DESCRIPTION
Three new queries for the HMRC 'renew tax credits' demo dashboard. 

And update cronjobs. 
