### PR TITLE
Amend CA time taken query

### DIFF
--- a/queries/carers-allowance/time-taken-to-complete.json
+++ b/queries/carers-allowance/time-taken-to-complete.json
@@ -14,7 +14,7 @@
       "eventLabel"
     ],
     "filters": [
-      "eventCategory==carers-allowance;ga:eventLabel==thank-you"
+      "eventCategory==carers-allowance"
     ],
     "id": "ga:75455468",
     "metrics": [


### PR DESCRIPTION
Don't filter by eventLabel after all: this is so we can use the
consent-and-declaration label instead if needed.
