### PR TITLE
Fix volumetrics for tier 2 visit visas

### DIFF
--- a/queries/tier-2-visit-visa/volumetrics.json
+++ b/queries/tier-2-visit-visa/volumetrics.json
@@ -7,7 +7,7 @@
   "options": {},
   "query": {
     "filters": [
-      "pagePath=~^/customer/[^/]+/complete$"
+      "pagePath=~^/customer/tier2-general/complete$"
     ],
     "id": "ga:81779532",
     "metrics": [


### PR DESCRIPTION
It should only show completes for tier2-general.
