### PR TITLE
Add operating system data to GOVUK browser info

### DIFF
--- a/queries/govuk/browsers.json
+++ b/queries/govuk/browsers.json
@@ -1,19 +1,21 @@
 {
   "data-set": {
-    "data-group": "govuk", 
+    "data-group": "govuk",
     "data-type": "browsers"
-  }, 
-  "entrypoint": "performanceplatform.collector.ga", 
-  "options": {}, 
+  },
+  "entrypoint": "performanceplatform.collector.ga",
+  "options": {},
   "query": {
     "dimensions": [
-      "browser", 
-      "browserVersion"
-    ], 
-    "id": "ga:53872948", 
+      "browser",
+      "browserVersion",
+      "operatingSystem",
+      "operatingSystemVersion"
+    ],
+    "id": "ga:53872948",
     "metrics": [
       "visitors"
     ]
-  }, 
+  },
   "token": "ga"
 }


### PR DESCRIPTION
At the moment it is hard to work out if Safari is desktop or mobile or
what version of iOS or Android the browsers are being used from. With
this extra information you can use the operatingSystemVersion for
friendly Android and iOS browser versions and operatingSystem for iOS or
OSX.

I believe this is the right way of adding this extra information. However if I am wrong please feel free to point me in the right direction.
