### PR TITLE
Add queries for collecting data across GOV.UK

### DIFF
--- a/queries/govuk-info/page-statistics.json
+++ b/queries/govuk-info/page-statistics.json
@@ -1,0 +1,25 @@
+{
+  "data-set": {
+    "data-group": "govuk-info", 
+    "data-type": "page-statistics"
+  }, 
+  "entrypoint": "performanceplatform.collector.ga", 
+  "options": {
+  }, 
+  "query": {
+    "frequency": "daily",
+    "dimensions": [
+      "pagePath",
+      "pageTitle"
+    ], 
+    "filters": [
+      "pageTitle!~(3[0-9]{2} |4[0-9]{2} |5[0-9]{2} |An error has occurred)"
+    ], 
+    "id": "ga:53872948", 
+    "metrics": [
+      "uniquePageviews",
+      "avgTimeOnPage"
+    ]
+  }, 
+  "token": "ga"
+}

--- a/queries/govuk-info/search-terms.json
+++ b/queries/govuk-info/search-terms.json
@@ -1,0 +1,27 @@
+{
+  "data-set": {
+    "data-group": "govuk-info", 
+    "data-type": "search-terms"
+  }, 
+  "entrypoint": "performanceplatform.collector.ga", 
+  "options": {
+    "mappings": {
+      "searchStartPage": "pagePath"
+    }
+  }, 
+  "query": {
+    "frequency": "daily",
+    "dimensions": [
+      "searchStartPage",
+      "searchKeyword"
+    ], 
+    "filters": [
+      "ga:searchUniques>10"
+    ], 
+    "id": "ga:53872948", 
+    "metrics": [
+      "searchUniques"
+    ]
+  }, 
+  "token": "ga"
+}


### PR DESCRIPTION
We want data about how many views any page on GOV.UK has had as well as
information about in page searches for them.
