### PR TITLE
Filter lasting power of attorney journey data

### DIFF
--- a/queries/lasting-power-of-attorney/journey.json
+++ b/queries/lasting-power-of-attorney/journey.json
@@ -17,7 +17,7 @@
       "eventLabel"
     ], 
     "filters": [
-      "eventCategory==stageprompt.lpa;ga:eventLabel!~^user/forgotpw/email/.*$;ga:eventLabel!~^activate/.*$"
+      "eventCategory==stageprompt.lpa;ga:eventLabel!~^user/forgotpw/email/.*$;ga:eventLabel!~^activate/.*$;ga:eventLabel=~^(create|user|register)/.*$"
     ], 
     "id": "ga:74575786", 
     "metrics": [


### PR DESCRIPTION
LPA Google Analytics events include a lot of junk data, so we should remove as much of that as we can before we store it in Backdrop.
