### PR TITLE
Add digital service store collectors

### DIFF
--- a/queries/digital-services-store/browsers.json
+++ b/queries/digital-services-store/browsers.json
@@ -1,0 +1,19 @@
+{
+  "data-set": {
+    "data-group": "digital-service-store",
+    "data-type": "browsers"
+  },
+  "entrypoint": "performanceplatform.collector.ga",
+  "options": {},
+  "query": {
+    "dimensions": [
+      "browser",
+      "browserVersion"
+    ],
+    "id": "ga:45708254",
+    "metrics": [
+      "visitors"
+    ]
+  },
+  "token": "ga"
+}

--- a/queries/digital-services-store/devices.json
+++ b/queries/digital-services-store/devices.json
@@ -1,0 +1,18 @@
+{
+  "data-set": {
+    "data-group": "digital-service-store",
+    "data-type": "devices"
+  },
+  "entrypoint": "performanceplatform.collector.ga",
+  "options": {},
+  "query": {
+    "dimensions": [
+      "deviceCategory"
+    ],
+    "id": "ga:45708254",
+    "metrics": [
+      "visitors"
+    ]
+  },
+  "token": "ga"
+}

--- a/queries/digital-services-store/monitoring.json
+++ b/queries/digital-services-store/monitoring.json
@@ -1,0 +1,12 @@
+{
+  "data-set": {
+    "data-group": "digital-service-store",
+    "data-type": "monitoring"
+  },
+  "entrypoint": "performanceplatform.collector.pingdom",
+  "options": {},
+  "query": {
+    "name": "digital_service_store"
+  },
+  "token": "pingdom"
+}

--- a/queries/digital-services-store/realtime.json
+++ b/queries/digital-services-store/realtime.json
@@ -1,0 +1,13 @@
+{
+  "data-set": {
+    "data-group": "digital-service-store",
+    "data-type": "realtime"
+  },
+  "entrypoint": "performanceplatform.collector.ga.realtime",
+  "options": {},
+  "query": {
+    "ids": "ga:45708254",
+    "metrics": "ga:activeVisitors"
+  },
+  "token": "ga-realtime"
+}

--- a/queries/digital-services-store/traffic-count.json
+++ b/queries/digital-services-store/traffic-count.json
@@ -1,0 +1,17 @@
+{
+  "data-set": {
+    "data-group": "digital-service-store",
+    "data-type": "traffic-count"
+  },
+  "entrypoint": "performanceplatform.collector.ga",
+  "options": {},
+  "query": {
+    "dimensions": [],
+    "id": "ga:45708254",
+    "metrics": [
+      "visitors",
+      "pageviews"
+    ]
+  },
+  "token": "ga"
+}


### PR DESCRIPTION
This is a copy of the digital marketplace collector config as the
dashboards will be the same. I have created a new check in pingdom for
the required service page, in the same way as the digital marketplace
check is setup.
