### PR TITLE
Change tax-disc realtime to vehicle-tax

### DIFF
--- a/queries/tax-disc/realtime.json
+++ b/queries/tax-disc/realtime.json
@@ -6,7 +6,7 @@
   "entrypoint": "performanceplatform.collector.ga.realtime", 
   "options": {}, 
   "query": {
-    "filters": "ga:pagePath=~^/tax-disc$", 
+    "filters": "ga:pagePath=~^/vehicle-tax$",
     "ids": "ga:84778268", 
     "metrics": "ga:activeVisitors"
   }, 


### PR DESCRIPTION
This slug was redirected on GOV.UK, so update where we're looking for realtime data from.
