### PR TITLE
Add collectors for time taken to complete

### DIFF
--- a/queries/driving-test-practical-public/time-to-complete-by-event.json
+++ b/queries/driving-test-practical-public/time-to-complete-by-event.json
@@ -1,0 +1,22 @@
+{
+  "data-set": {
+    "data-group": "driving-test-practical-public", 
+    "data-type": "time-to-complete-by-event"
+  }, 
+  "entrypoint": "performanceplatform.collector.ga", 
+  "options": {
+  }, 
+  "query": {
+    "dimensions": [
+      "eventCategory", 
+      "eventAction"
+    ], 
+    "filters": "ga:eventCategory=~^pp-.*;ga:eventAction=~^booking-complete$,ga:eventAction=~^confirm-changes$,ga:eventAction=~^confirm-cancellation$", 
+    "id": "ga:64942391", 
+    "metrics": [
+      "sessions",
+      "avgSessionDuration"
+    ]
+  }, 
+  "token": "ga"
+}


### PR DESCRIPTION
- Use pp events to filter data
- New datatype: time-to-complete-by-event
- New dataset to hold metrics
- Collects bookings/changes/cancellations in single dataset
