### PR TITLE
Add collector for time taken to complete

### DIFF
--- a/queries/paye-employee-company-car/time-to-complete-by-event.json
+++ b/queries/paye-employee-company-car/time-to-complete-by-event.json
@@ -1,0 +1,22 @@
+{
+  "data-set": {
+    "data-group": "paye-employee-company-car", 
+    "data-type": "time-to-complete-by-event"
+  }, 
+  "entrypoint": "performanceplatform.collector.ga", 
+  "options": {
+  }, 
+  "query": {
+    "dimensions": [
+      "eventCategory", 
+      "eventAction"
+    ], 
+    "filters": "ga:eventCategory=~^pp|paye-for-employees|company-car$;ga:eventAction=~^confirmation.*,ga:eventAction=~^your-car-details$", 
+    "id": "ga:84353061", 
+    "metrics": [
+      "sessions",
+      "avgSessionDuration"
+    ]
+  }, 
+  "token": "ga"
+}


### PR DESCRIPTION
measures time for each transaction within the service
users can do more than one activity before exit
more detailed measure that total 'time to sign off page'

using pp events to filter data
new dataset create -(time-take-to-complete-by-event
collects:
- view car details
- add car
- remove car
- replace car
- add fuel
- remove fuel
