### PR TITLE
Update PAYE compant car time to complete

### DIFF
--- a/queries/paye-employee-company-car/time-taken-to-complete.json
+++ b/queries/paye-employee-company-car/time-taken-to-complete.json
@@ -11,9 +11,6 @@
     "id": "ga:84353061", 
     "metrics": [
       "avgSessionDuration"
-    ],
-    "filters": [
-      "pagePath==/paye/company-car/signout"
     ]
   }, 
   "token": "ga"


### PR DESCRIPTION
remove page filter for final stage
application model causes incorrect session measure
led to reporting zero time on transaction
removal of filter provides overall aggregate
