### PR TITLE
Updating README to remove reference to updating cronjobs file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,6 @@ Creating a new query
 
 Add a new config file in :code:`/queries`.
 
-Update the cronjobs: :code:`python tools/cronjobs.py > cronjobs`.
 
 Query Reference
 ===============


### PR DESCRIPTION
Cronjobs are now generated on deployment (see https://github.com/alphagov/performanceplatform-collector-config/pull/87).
