### PR TITLE
Filter causing failed time response

### DIFF
--- a/queries/report-a-lost-or-stolen-passport/time-taken-to-complete.json
+++ b/queries/report-a-lost-or-stolen-passport/time-taken-to-complete.json
@@ -13,7 +13,6 @@
       "avgSessionDuration"
     ],
     "filters": [
-      "pagePath==/report/completed"
     ]
   }, 
   "token": "ga"


### PR DESCRIPTION
filtering session time by repoty/complete gives error
to compensate, remove filter - average session across
success and failed transactions
