### PR TITLE
Adding collectors for Your Tax Account dashboard

### DIFF
--- a/queries/your-tax-account/browser-usage.json
+++ b/queries/your-tax-account/browser-usage.json
@@ -1,0 +1,23 @@
+{
+  "data-set": {
+    "data-group": "your-tax-account",
+    "data-type": "browser-usage"
+  }, 
+  "entrypoint": "performanceplatform.collector.ga", 
+  "options": {}, 
+  "query": {
+    "dimensions": [
+      "browser",
+      "browserVersion"
+    ], 
+    "id": "ga:84617412",
+    "metrics": [
+      "sessions"
+    ],
+    "sort": [
+      "-sessions"
+    ],
+    "maxResults": 100
+  }, 
+  "token": "ga"
+}

--- a/queries/your-tax-account/device-usage.json
+++ b/queries/your-tax-account/device-usage.json
@@ -1,0 +1,21 @@
+{
+  "data-set": {
+    "data-group": "your-tax-account", 
+    "data-type": "device-usage"
+  }, 
+  "entrypoint": "performanceplatform.collector.ga", 
+  "options": {}, 
+  "query": {
+    "dimensions": [
+      "deviceCategory"
+    ], 
+    "id": "ga:84617412", 
+    "metrics": [
+      "sessions"
+    ],
+    "sort": [
+      "-sessions"
+    ]
+  }, 
+  "token": "ga"
+}

--- a/queries/your-tax-account/journey-by-page-events.json
+++ b/queries/your-tax-account/journey-by-page-events.json
@@ -1,0 +1,30 @@
+{
+  "data-set": {
+    "data-group": "your-tax-account", 
+    "data-type": "journey-by-page"
+  }, 
+  "entrypoint": "performanceplatform.collector.ga", 
+  "options": {
+    "additionalFields": {
+      "service_identifier": "pp|your-tax-account",
+      "eventType": "stage",
+      "eventDetail": "routing"
+    },
+    "mappings": {
+      "eventCategory": "journey_stage"
+    },
+    "idMapping": ["_timestamp", "timeSpan", "service_identifier", "journey_stage", "eventType", "eventDetail"]
+  }, 
+  "query": {
+    "id": "ga:84617412",
+    "dimensions": [
+      "eventCategory"
+    ],
+    "metrics": [
+      "totalEvents",
+      "uniqueEvents"
+    ],
+    "filters": "ga:pagePath==/account;ga:eventCategory!~^footer;ga:eventCategory!~^header;ga:eventCategory!~^primary-navigation;ga:eventCategory!~^sidebar"
+  }, 
+  "token": "ga"
+}

--- a/queries/your-tax-account/journey-by-page-start.json
+++ b/queries/your-tax-account/journey-by-page-start.json
@@ -1,0 +1,25 @@
+{
+  "data-set": {
+    "data-group": "your-tax-account", 
+    "data-type": "journey-by-page"
+  }, 
+  "entrypoint": "performanceplatform.collector.ga", 
+  "options": {
+    "additionalFields": {
+      "service_identifier": "pp|your-tax-account",
+      "journey_stage": "account",
+      "eventType": "stage",
+      "eventDetail": "routing"
+    },
+    "idMapping": ["_timestamp", "timeSpan", "service_identifier", "journey_stage", "eventType", "eventDetail"]
+  }, 
+  "query": {
+    "id": "ga:84617412",
+    "metrics": [
+      "totalEvents",
+      "uniqueEvents"
+    ],
+    "filters": "ga:pagePath==/account"
+  }, 
+  "token": "ga"
+}

--- a/queries/your-tax-account/new-returning-users.json
+++ b/queries/your-tax-account/new-returning-users.json
@@ -1,0 +1,19 @@
+{
+  "data-set": {
+    "data-group": "your-tax-account", 
+    "data-type": "new-returning-users"
+  }, 
+  "entrypoint": "performanceplatform.collector.ga", 
+  "options": {}, 
+  "query": {
+    "id": "ga:84617412",
+    "dimensions": [
+      "userType"
+    ],
+    "metrics": [
+      "sessions",
+      "users"
+    ]
+  }, 
+  "token": "ga"
+}

--- a/queries/your-tax-account/realtime.json
+++ b/queries/your-tax-account/realtime.json
@@ -1,0 +1,13 @@
+{
+  "data-set": {
+    "data-group": "your-tax-account", 
+    "data-type": "realtime"
+  }, 
+  "entrypoint": "performanceplatform.collector.ga.realtime", 
+  "options": {}, 
+  "query": {
+    "ids": "ga:84617412", 
+    "metrics": "ga:activeVisitors"
+  }, 
+  "token": "ga-realtime"
+}

--- a/queries/your-tax-account/time-taken-to-complete.json
+++ b/queries/your-tax-account/time-taken-to-complete.json
@@ -1,0 +1,17 @@
+{
+  "data-set": {
+    "data-group": "your-tax-account", 
+    "data-type": "time-taken-to-complete"
+  }, 
+  "entrypoint": "performanceplatform.collector.ga", 
+  "options": {}, 
+  "query": {
+    "dimensions": [
+    ], 
+    "id": "ga:84617412", 
+    "metrics": [
+      "avgSessionDuration"
+    ]
+  }, 
+  "token": "ga"
+}

--- a/queries/your-tax-account/traffic-count.json
+++ b/queries/your-tax-account/traffic-count.json
@@ -1,0 +1,16 @@
+{
+  "data-set": {
+    "data-group": "your-tax-account",
+    "data-type": "traffic-count"
+  },
+  "entrypoint": "performanceplatform.collector.ga",
+  "options": {},
+  "query": {
+    "id": "ga:84617412",
+    "metrics": [
+      "users",
+      "pageviews"
+    ]
+  },
+  "token": "ga"
+}


### PR DESCRIPTION
6 standard collectors;
journey-by-page-start - collects totalEvents and uniqueEvents (used for displaying onward journey intent);
journey-by-page-events - collects a number of totalEvents and uniqueEvents which occur on the account page (used as above). 
