### PR TITLE
Exit with 1 when we have an exception

### DIFF
--- a/tools/cronjobs.py
+++ b/tools/cronjobs.py
@@ -181,6 +181,7 @@ def main():
         print('\n'.join(cronjobs_content))
     except ValueError as e:
         print(e.message, file=sys.stderr)
+        sys.exit(1)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
It is a bit rude to exit with a status of 0 when the script has not
finished executing due to an error.
