### PR TITLE
Add entry for piwik.core in cronjobs.py

### DIFF
--- a/tools/cronjobs.py
+++ b/tools/cronjobs.py
@@ -38,7 +38,7 @@ entrypoint_information = {
         'repeat': 'hourly',
     },
     'performanceplatform.collector.piwik.core': {
-        'credentials': 'credentials/piwik-fco-test.json',
+        'credentials': 'credentials/piwik_fco.json',
         'repeat': 'daily',
     },
     'performanceplatform.collector.gcloud': {

--- a/tools/cronjobs.py
+++ b/tools/cronjobs.py
@@ -37,6 +37,10 @@ entrypoint_information = {
         'credentials': 'credentials/pingdom.json',
         'repeat': 'hourly',
     },
+    'performanceplatform.collector.piwik.core': {
+        'credentials': 'credentials/piwik-fco-test.json',
+        'repeat': 'daily',
+    },
     'performanceplatform.collector.gcloud': {
         'credentials': 'credentials/gcloud.json',
         'repeat': 'hourly',


### PR DESCRIPTION
`cronjobs.py` expects there to be an entry in this hash in order to work
out how often it should run the collector. If there is one missing it
blows up. There wasn't one added for piwik so it blew up, adding this
should make it all run buttery smooth.

As it is similar to GA I have configured it to run at the same frequency
as it. Daily for the win!
