### PR TITLE
Updating the Digital Service Store collectors to use an alternative view ID

### DIFF
--- a/queries/digital-services-store/browsers.json
+++ b/queries/digital-services-store/browsers.json
@@ -10,7 +10,7 @@
       "browser",
       "browserVersion"
     ],
-    "id": "ga:85286707",
+    "id": "ga:93569916",
     "metrics": [
       "visitors"
     ]

--- a/queries/digital-services-store/devices.json
+++ b/queries/digital-services-store/devices.json
@@ -9,7 +9,7 @@
     "dimensions": [
       "deviceCategory"
     ],
-    "id": "ga:85286707",
+    "id": "ga:93569916",
     "metrics": [
       "visitors"
     ]

--- a/queries/digital-services-store/realtime.json
+++ b/queries/digital-services-store/realtime.json
@@ -6,7 +6,7 @@
   "entrypoint": "performanceplatform.collector.ga.realtime",
   "options": {},
   "query": {
-    "ids": "ga:85286707",
+    "ids": "ga:93569916",
     "metrics": "ga:activeVisitors"
   },
   "token": "ga-realtime"

--- a/queries/digital-services-store/traffic-count.json
+++ b/queries/digital-services-store/traffic-count.json
@@ -7,7 +7,7 @@
   "options": {},
   "query": {
     "dimensions": [],
-    "id": "ga:85286707",
+    "id": "ga:93569916",
     "metrics": [
       "visitors",
       "pageviews"


### PR DESCRIPTION
This view screens out IP addresses from us and the development team
