### PR TITLE
Set carers realtime metrics to use realtime identifier

### DIFF
--- a/queries/carers-allowance-change-of-circs/realtime.json
+++ b/queries/carers-allowance-change-of-circs/realtime.json
@@ -7,7 +7,7 @@
   "options": {}, 
   "query": {
     "ids": "ga:96604342", 
-    "metrics": "ga:activeUsers"
+    "metrics": "rt:activeUsers"
   }, 
   "token": "ga-realtime"
 }

--- a/queries/carers-allowance/realtime.json
+++ b/queries/carers-allowance/realtime.json
@@ -7,7 +7,7 @@
   "options": {}, 
   "query": {
     "ids": "ga:94954354", 
-    "metrics": "ga:activeUsers"
+    "metrics": "rt:activeUsers"
   }, 
   "token": "ga-realtime"
 }


### PR DESCRIPTION
Change ga:activeUsers to rt:activeUsers

Requirement for switch to GA universal

modified for:
- carers allowance
- carers allowance - change of circumstances
