### PR TITLE
Adding entry for NHS Choices to cronjobs.py

### DIFF
--- a/tools/cronjobs.py
+++ b/tools/cronjobs.py
@@ -21,6 +21,18 @@ entrypoint_information = {
             'webtrends_national_apprenticeship_scheme.json'},
         'repeat': 'hourly',
     },
+    'performanceplatform.collector.webtrends.reports': {
+        'credentials': {
+            u'nhs-choices': 'credentials/'
+            'webtrends_nhs_choices.json'},
+        'repeat': 'daily',
+    },
+    'performanceplatform.collector.webtrends.keymetrics': {
+        'credentials': {
+            u'nhs-choices': 'credentials/'
+            'webtrends_nhs_choices.json'},
+        'repeat': 'hourly',
+    },
     'performanceplatform.collector.ga.trending': {
         'credentials': 'credentials/ga.json',
         'repeat': 'daily',


### PR DESCRIPTION
This is a new webtrends collector so the cronjobs needs to know about it.

Detailed explanation here - https://github.com/alphagov/performanceplatform-collector-config/pull/126.
