### PR TITLE
Updating journey-by-goal collector for Assign personal registration

### DIFF
--- a/queries/assign-personal-registration/journey-by-goal-start.json
+++ b/queries/assign-personal-registration/journey-by-goal-start.json
@@ -6,7 +6,7 @@
   "entrypoint": "performanceplatform.collector.ga", 
   "options": {
     "additionalFields": {
-      "eventCategory": "pp|retain-personalised-registration",
+      "eventCategory": "pp|assign-personalised-registration",
       "eventAction": "start",
       "eventType": "stage",
       "eventDetail": "transaction"


### PR DESCRIPTION
eventCategory should be assign not retain.
