### PR TITLE
Fix schema failings

### DIFF
--- a/queries/accelerated-possession-eviction/journey-completions.json
+++ b/queries/accelerated-possession-eviction/journey-completions.json
@@ -11,7 +11,7 @@
     "mappings": {
       "goal4Completions": "count"
     },
-    "idMappings": ["_timestamp", "timeSpan", "stage"]
+    "idMapping": ["_timestamp", "timeSpan", "stage"]
   }, 
   "query": {
     "id": "ga:86360471", 

--- a/queries/licensing/browsers.json
+++ b/queries/licensing/browsers.json
@@ -11,7 +11,7 @@
       "browserVersion"
     ],
     "filters": "ga:pagePath=~/apply-for-a-licence",
-    "ids": "ga:84779739",
+    "id": "ga:84779739",
     "metrics": [
       "visitors"
     ]

--- a/queries/licensing/devices.json
+++ b/queries/licensing/devices.json
@@ -10,7 +10,7 @@
       "deviceCategory"
     ],
     "filters": "ga:pagePath=~/apply-for-a-licence",
-    "ids": "ga:84779739",
+    "id": "ga:84779739",
     "metrics": [
       "visitors"
     ]


### PR DESCRIPTION
We have now defined schemata for the collector types and these were in
breach. id is expected rather than ids that ends up getting submitted to
the API, because gapy. idMapping as always been idMapping so the id
structure of that dataset is going to change as this will finally work.
