### PR TITLE
Create crontab lines with collector slug argument.

### DIFF
--- a/tools/cronjobs.py
+++ b/tools/cronjobs.py
@@ -58,64 +58,64 @@ entrypoint_information = {
 
 def daily(jobs):
     entries = ['#', '# Daily jobs', '#', '']
-    for index, (query, credentials, token) in enumerate(jobs):
+    for index, (collector, credentials, token) in enumerate(jobs):
         hour, minute = divmod(index, 60)
         entries.append(
             '{0} {1} * * *,{2},{3},{4},performanceplatform.json'
-            .format(minute, hour, query, credentials, token))
+            .format(minute, hour, collector['slug'], credentials, token))
     return entries
 
 
 def hourly(jobs):
     entries = ['#', '# Hourly jobs', '#', '']
-    for index, (query, credentials, token) in enumerate(jobs):
+    for index, (collector, credentials, token) in enumerate(jobs):
         minute = index % 60
         entries.append(
             '{0} * * * *,{1},{2},{3},performanceplatform.json'
-            .format(minute, query, credentials, token))
+            .format(minute, collector['slug'], credentials, token))
     return entries
 
 
 def two_minute(jobs):
     entries = ['#', '# Run every two minutes', '#', '']
-    for index, (query, credentials, token) in enumerate(jobs):
+    for index, (collector, credentials, token) in enumerate(jobs):
         entries.append(
             '1-59/2 * * * *,{0},{1},{2},performanceplatform.json'
-            .format(query, credentials, token))
+            .format(collector['slug'], credentials, token))
     return entries
 
 
 def setup_time_data_set(
-        query_info,
-        query,
+        collector_info,
+        collector,
         token_file,
         data_group):
 
     """Using default repeat
     >>> token_file = 'abc.txt'
-    >>> query = {"some": 'query'}
-    >>> query_info = {
+    >>> collector = {"some": 'query', "entry_point": "entry.point"}
+    >>> collector_info = {
     ... 'credentials': 'credentials/ga.json',
     ... 'repeat': 'daily',
     ... }
-    >>> setup_time_data_set(query_info, query, token_file, None)
-    ({'some': 'query'}, 'credentials/ga.json', 'abc.txt')
-    >>> query_info = {
+    >>> setup_time_data_set(collector_info, collector, token_file, None)
+    ({'entry_point': 'entry.point', 'some': 'query'}, 'credentials/ga.json', 'abc.txt')
+    >>> collector_info = {
     ... 'credentials': {'nas':'credentials/ga.json'},
     ... 'repeat': 'daily',
     ... }
-    >>> setup_time_data_set(query_info, query, token_file, 'nas')
-    ({'some': 'query'}, 'credentials/ga.json', 'abc.txt')
+    >>> setup_time_data_set(collector_info, collector, token_file, 'nas')
+    ({'entry_point': 'entry.point', 'some': 'query'}, 'credentials/ga.json', 'abc.txt')
 
     """
-    credentials_file = query_info['credentials']
+    credentials_file = collector_info['credentials']
     if type(credentials_file) == dict:
         credentials_file = credentials_file[data_group]
 
-    return (query, credentials_file, token_file)
+    return (collector, credentials_file, token_file)
 
 
-def setup_time_data_sets(queries, entrypoint_information):
+def setup_time_data_sets(collectors, entrypoint_information):
     """Testing returns correct time grouped data sets
     >>> entrypoint_information = {
     ...   'performanceplatform.collector.pingdom': {
@@ -123,60 +123,96 @@ def setup_time_data_sets(queries, entrypoint_information):
     ...     'repeat': 'daily'
     ...   }
     ... }
-    >>> queries = ['queries/bis-payment-of-patent-renewal-fee-f12/monitoring.json']  # noqa
-    >>> setup_time_data_sets(queries, entrypoint_information)
-    {'daily': [('queries/bis-payment-of-patent-renewal-fee-f12/monitoring.json', 'credentials/ga.json', 'tokens/pingdom.json')]}
+    >>> collectors = [{
+    ...   'slug': 'test-collector',
+    ...   'entry_point': 'performanceplatform.collector.pingdom',
+    ...   'provider': {'slug': 'pingdom'},
+    ...   'data_set': {'data_group': 'test_data_group'}
+    ... }]  # noqa
+    >>> setup_time_data_sets(collectors, entrypoint_information) #doctest: +NORMALIZE_WHITESPACE
+    {'daily': [({'data_set': {'data_group': 'test_data_group'},
+    'entry_point': 'performanceplatform.collector.pingdom',
+    'slug': 'test-collector',
+    'provider': {'slug': 'pingdom'}},
+    'credentials/ga.json',
+    'tokens/pingdom.json')]}
     >>> entrypoint_information = {
     ...   'performanceplatform.collector.pingdom': {
     ...     'credentials': 'credentials/ga.json',
-    ...     'repeat': 'daily'
+    ...     'repeat': 'hourly'
     ...   }
     ... }
-    >>> queries = ['test/fixtures/query_with_repeat.json']
-    >>> setup_time_data_sets(queries, entrypoint_information)
-    {u'hourly': [('test/fixtures/query_with_repeat.json', 'credentials/ga.json', 'tokens/pingdom.json')]}
+    >>> collectors = [{
+    ...   'slug': 'test-collector',
+    ...   'entry_point': 'performanceplatform.collector.pingdom',
+    ...   'provider': {'slug': 'pingdom'},
+    ...   'data_set': {'data_group': 'test_data_group'}
+    ... }]
+    >>> setup_time_data_sets(collectors, entrypoint_information) #doctest: +NORMALIZE_WHITESPACE
+    {'hourly': [({'data_set': {'data_group': 'test_data_group'},
+    'entry_point': 'performanceplatform.collector.pingdom',
+    'slug': 'test-collector',
+    'provider': {'slug': 'pingdom'}},
+    'credentials/ga.json',
+    'tokens/pingdom.json')]}
     """
     time_data_sets = {}
-    for query in queries:
-        with open(query) as query_fd:
-            try:
-                query_json = json.load(query_fd)
-            except ValueError:
-                raise ValueError("Invalid JSON in {}".format(query))
-            entrypoint = query_json['entrypoint']
-            token_file = "tokens/{0}.json".format(query_json['token'])
+    for collector in collectors:
+        entrypoint = collector.get('entry_point')
+        token_file = "tokens/{0}.json".format(
+            collector.get('provider').get('slug'))
 
-        query_info = entrypoint_information.get(entrypoint, None)
+        collector_info = entrypoint_information.get(entrypoint, None)
 
-        if query_info is None:
+        if collector_info is None:
             raise ValueError(
-                "No entrypoint {0} from {1}".format(entrypoint, query))
+                "No entrypoint {0} from {1}".format(entrypoint, collector))
 
-        repeat = query_json.get('repeat', query_info['repeat'])
+        repeat = collector.get('repeat', collector_info['repeat'])
 
         if repeat not in time_data_sets:
             time_data_sets[repeat] = []
 
         time_data_sets[repeat].append(setup_time_data_set(
-            query_info,
-            query,
+            collector_info,
+            collector,
             token_file,
-            query_json['data-set']['data-group']))
+            collector['data_set']['data_group']))
+
 
     return time_data_sets
 
 
 def main():
-    try:
-        queries = [
-            os.path.join(dp, f) for dp, dn, filenames
-            in os.walk('queries') for f in filenames
-            if os.path.splitext(f)[1] == '.json']
-        time_data_sets = setup_time_data_sets(queries, entrypoint_information)
+    with open('performanceplatform.json', 'r') as f:
+        environment_config = json.load(f)
 
-        daily_jobs = daily(time_data_sets['daily'])
-        hourly_jobs = hourly(time_data_sets['hourly'])
-        two_minute_jobs = two_minute(time_data_sets['2minute'])
+    stagecraft_url = environment_config['stagecraft_url'].replace(
+        "http://","",1)
+
+    from httplib import HTTPSConnection
+    conn = HTTPSConnection(stagecraft_url)
+
+    token = environment_config['omniscient_api_token']
+    headers = {
+        "Authorization": "Bearer {}".format(token)
+    }
+    conn.request("GET", "/collector", headers=headers)
+    resp = conn.getresponse()
+    data = resp.read()
+
+    collectors = json.loads(data)
+
+    try:
+        time_data_sets = setup_time_data_sets(collectors,
+                                              entrypoint_information)
+
+        daily_jobs = daily(time_data_sets['daily']) \
+            if 'daily' in time_data_sets else []
+        hourly_jobs = hourly(time_data_sets['hourly']) \
+            if 'hourly' in time_data_sets else []
+        two_minute_jobs = two_minute(time_data_sets['2minute']) \
+            if '2minute' in time_data_sets else []
 
         spacer = ['', '']
         cronjobs_content = [


### PR DESCRIPTION
Update crontab line generation to the get config for every collector
from stagecraft and then populate the crontab lines with the collector
slug rather than the location of the query file.

Dependent on: https://github.com/alphagov/performanceplatform-collector/pull/126

Pivotal: https://www.pivotaltracker.com/story/show/98935742

Should be merged after the collector configs have been migrated to stagecraft.
