### PR TITLE
Add option for emptying dataset.

### DIFF
--- a/queries/govuk/most_viewed.json
+++ b/queries/govuk/most_viewed.json
@@ -1,27 +1,28 @@
 {
   "data-set": {
-    "data-group": "govuk", 
+    "data-group": "govuk",
     "data-type": "most_viewed"
-  }, 
-  "entrypoint": "performanceplatform.collector.ga", 
+  },
+  "entrypoint": "performanceplatform.collector.ga",
   "options": {
     "idMapping": [
-      "pagePath", 
+      "pagePath",
       "pageTitle"
-    ]
-  }, 
+    ],
+    "empty-data-set": true
+  },
   "query": {
     "dimensions": [
-      "pageTitle", 
+      "pageTitle",
       "pagePath"
-    ], 
+    ],
     "filters": [
       "pagePath!~^(/$|/(.*-finished$|transformation|service-manual|performance|government|search|done|print|help).*);ga:pageTitle!~(3[0-9]{2} |4[0-9]{2} |5[0-9]{2} |An error has occurred)"
-    ], 
-    "id": "ga:53872948", 
+    ],
+    "id": "ga:53872948",
     "metrics": [
       "pageviews"
     ]
-  }, 
+  },
   "token": "ga"
 }

--- a/queries/govuk/most_viewed_news.json
+++ b/queries/govuk/most_viewed_news.json
@@ -1,27 +1,28 @@
 {
   "data-set": {
-    "data-group": "govuk", 
+    "data-group": "govuk",
     "data-type": "most_viewed_news"
-  }, 
-  "entrypoint": "performanceplatform.collector.ga", 
+  },
+  "entrypoint": "performanceplatform.collector.ga",
   "options": {
     "idMapping": [
-      "pagePath", 
+      "pagePath",
       "pageTitle"
-    ]
-  }, 
+    ],
+    "empty-data-set": true
+  },
   "query": {
     "dimensions": [
-      "pageTitle", 
+      "pageTitle",
       "pagePath"
-    ], 
+    ],
     "filters": [
       "pagePath=~^/government/(news|speeches).*"
-    ], 
-    "id": "ga:53872948", 
+    ],
+    "id": "ga:53872948",
     "metrics": [
       "pageviews"
     ]
-  }, 
+  },
   "token": "ga"
 }

--- a/queries/govuk/most_viewed_policies.json
+++ b/queries/govuk/most_viewed_policies.json
@@ -1,27 +1,28 @@
 {
   "data-set": {
-    "data-group": "govuk", 
+    "data-group": "govuk",
     "data-type": "most_viewed_policies"
-  }, 
-  "entrypoint": "performanceplatform.collector.ga", 
+  },
+  "entrypoint": "performanceplatform.collector.ga",
   "options": {
     "idMapping": [
-      "pagePath", 
+      "pagePath",
       "pageTitle"
-    ]
-  }, 
+    ],
+    "empty-data-set": true
+  },
   "query": {
     "dimensions": [
-      "pageTitle", 
+      "pageTitle",
       "pagePath"
-    ], 
+    ],
     "filters": [
       "pagePath=~^/government/policies.+"
-    ], 
-    "id": "ga:53872948", 
+    ],
+    "id": "ga:53872948",
     "metrics": [
       "pageviews"
     ]
-  }, 
+  },
   "token": "ga"
 }


### PR DESCRIPTION
Add a parameter to options that instructs the Google Analytics
core collector to purge the contents of dataset everytime it
collects more data.

This is so that the dataset will never contain more than the most
recent complete week's data and therefore only show the last seven
days worth of data on the dashboard.

Dependent on: https://github.com/alphagov/performanceplatform-collector/pull/132

Pivotal: https://www.pivotaltracker.com/story/show/100818900
