### PR TITLE
Use correct token files for collectors

### DIFF
--- a/tools/cronjobs.py
+++ b/tools/cronjobs.py
@@ -3,6 +3,7 @@ import json
 import os
 import re
 import sys
+import string
 
 
 entrypoint_information = {
@@ -150,6 +151,36 @@ def setup_time_data_set(
     return (collector, credentials_file, token_file)
 
 
+def get_token_file_from_collector(collector):
+    """
+    >>> get_token_file_from_collector({'type': {'slug':'ga-contrib-content-table'}})
+    'ga-content'
+    >>> get_token_file_from_collector({'type': {'slug': 'ga'}})
+    'ga'
+    >>> get_token_file_from_collector({'type': {'slug': 'webtrends-keymetrics'}})
+    'webtrends'
+    >>> get_token_file_from_collector({'data_source': {'slug': 'piwik-fco'}})
+    'piwik_fco'
+    >>> get_token_file_from_collector({'data_source': {'slug': 'piwik-fco'}, 'type': {'slug': 'piwik-realtime'}})
+    'piwik_fco_realtime'
+    >>> get_token_file_from_collector({'data_source': {'slug': 'piwik-verify'}})
+    'piwik_verify'
+    """
+    type_slug = collector.get('type', {}).get('slug', '')
+    if type_slug == 'ga-contrib-content-table':
+        return 'ga-content'
+    if string.find(type_slug, 'webtrends') >= 0:
+        return 'webtrends'
+    if collector.get('data_source', {}).get('slug') == 'piwik-fco':
+        if type_slug == 'piwik-realtime':
+            return 'piwik_fco_realtime'
+        else:
+            return 'piwik_fco'
+    if collector.get('data_source', {}).get('slug') == 'piwik-verify':
+        return 'piwik_verify'
+    return collector.get('type').get('slug')
+
+
 def setup_time_data_sets(collectors, entrypoint_information):
     """Testing returns correct time grouped data sets
     >>> entrypoint_information = {
@@ -195,7 +226,7 @@ def setup_time_data_sets(collectors, entrypoint_information):
     for collector in collectors:
         entrypoint = collector.get('entry_point')
         token_file = "tokens/{0}.json".format(
-            collector.get('type').get('slug'))
+            get_token_file_from_collector(collector))
 
         collector_info = entrypoint_information.get(entrypoint, None)
 


### PR DESCRIPTION
During the collector migration, we wrongly assumed that the token used
for the collector always matched the slug of the collector type. This
caused all govuk content, piwik and webtrends collectors to break as
they do not follow this pattern. So we have to add some special cases
for these.

This code is a bit ugly, but once the collectors are running fully
through stagecraft they will be able to derive the token used to write
to the dataset from the dataset config within stagecraft, so this is
only temporary.

This was tested by generating the crontab before and after the changes
were made, and checking the only collectors which changed token were the
broken ones.
